### PR TITLE
Add QPIWS PI30 basic support: RAW answer and MQTT topic of alerts list

### DIFF
--- a/src/PI_Serial/PI_Serial.cpp
+++ b/src/PI_Serial/PI_Serial.cpp
@@ -15,6 +15,7 @@ CRC16 crc;
 #include "QPIGS2.h"
 #include "QMOD.h"
 #include "QEX.h"
+#include "QPIWS.h"
 extern void writeLog(const char *format, ...);
 //----------------------------------------------------------------------
 //  Public Functions
@@ -92,6 +93,9 @@ bool PI_Serial::loop()
                     requestCounter = PIXX_QEX() ? (requestCounter + 1) : 0;
                     break;
                 case 5:
+                    requestCounter = PIXX_QPIWS() ? (requestCounter + 1) : 0;
+                    break;
+                case 6:
                     requestCallback();
                     requestCounter = 0;
                     break;

--- a/src/PI_Serial/PI_Serial.h
+++ b/src/PI_Serial/PI_Serial.h
@@ -1,7 +1,7 @@
 #include "SoftwareSerial.h"
 #ifndef PI_SERIAL_H
 #define PI_SERIAL_H
-
+#include "vector"
 #include <ArduinoJson.h>
 extern JsonObject deviceJson;
 extern JsonObject staticData;
@@ -40,6 +40,7 @@ public:
             String qlm;
             String qld;
             String commandAnswer;
+            String qpiws;
         } raw;
 
     } get;
@@ -144,6 +145,7 @@ private:
     bool PIXX_QPIGS2();
     bool PIXX_QMOD();
     bool PIXX_QEX();
+    bool PIXX_QPIWS();
     // static reqeuests
     bool PIXX_QPIRI();
     bool PIXX_QPI();

--- a/src/PI_Serial/QPIWS.h
+++ b/src/PI_Serial/QPIWS.h
@@ -1,0 +1,73 @@
+bool PI_Serial::PIXX_QPIWS()
+{
+    if (protocol == PI30)
+    {
+        String commandAnswer = this->requestData("QPIWS");
+        //String commandAnswer = "10000000001010000000000000000000";
+        get.raw.qpiws = commandAnswer;
+        byte commandAnswerLength = commandAnswer.length();
+        if (commandAnswer == "NAK")
+        {
+            return true;
+        }
+        if (commandAnswer == "ERCRC")
+        {
+            return false;
+        }
+        if (commandAnswerLength == 32)
+        {
+            std::vector<String> qpiwsStrings;
+            if ((char)commandAnswer.charAt(1) == '1') qpiwsStrings.emplace_back("Inverter fault"); // 2
+            if ((char)commandAnswer.charAt(2) == '1') qpiwsStrings.emplace_back("Bus over fault"); // 3
+            if ((char)commandAnswer.charAt(3) == '1') qpiwsStrings.emplace_back("Bus under fault"); // 4
+            if ((char)commandAnswer.charAt(4) == '1') qpiwsStrings.emplace_back("Bus soft fail fault"); // 5
+            if ((char)commandAnswer.charAt(5) == '1') qpiwsStrings.emplace_back("Line fail warning"); // 6
+            if ((char)commandAnswer.charAt(6) == '1') qpiwsStrings.emplace_back("OPV short warning"); // 7
+            if ((char)commandAnswer.charAt(7) == '1') qpiwsStrings.emplace_back("Inverter voltage too low fault"); // 8
+            if ((char)commandAnswer.charAt(8) == '1') qpiwsStrings.emplace_back("Inverter voltage too high fault"); // 9
+            if ((char)commandAnswer.charAt(9) == '1') qpiwsStrings.emplace_back("Over temperature fault"); // 10
+            if ((char)commandAnswer.charAt(10) == '1') qpiwsStrings.emplace_back("Fan locked fault"); // 11
+            if ((char)commandAnswer.charAt(11) == '1') qpiwsStrings.emplace_back("Battery voltage too high fault"); // 12
+            if ((char)commandAnswer.charAt(12) == '1') qpiwsStrings.emplace_back("Battery low alarm warning"); // 13
+            if ((char)commandAnswer.charAt(14) == '1') qpiwsStrings.emplace_back("Battery under shutdown warning"); // 15
+            if ((char)commandAnswer.charAt(16) == '1') qpiwsStrings.emplace_back("Overload fault"); // 17
+            if ((char)commandAnswer.charAt(17) == '1') qpiwsStrings.emplace_back("EEPROM fault"); // 18
+            if ((char)commandAnswer.charAt(18) == '1') qpiwsStrings.emplace_back("Inverter over current fault"); // 19
+            if ((char)commandAnswer.charAt(19) == '1') qpiwsStrings.emplace_back("Inverter soft fail fault"); // 20
+            if ((char)commandAnswer.charAt(20) == '1') qpiwsStrings.emplace_back("Self test fail fault"); // 21
+            if ((char)commandAnswer.charAt(21) == '1') qpiwsStrings.emplace_back("OP DC voltage over fault"); // 22
+            if ((char)commandAnswer.charAt(22) == '1') qpiwsStrings.emplace_back("Battery open fault"); // 23
+            if ((char)commandAnswer.charAt(23) == '1') qpiwsStrings.emplace_back("Current sensor fail fault"); // 24
+            if ((char)commandAnswer.charAt(24) == '1') qpiwsStrings.emplace_back("Battery short fault"); // 25
+            if ((char)commandAnswer.charAt(25) == '1') qpiwsStrings.emplace_back("Power limit warning"); // 26
+            if ((char)commandAnswer.charAt(26) == '1') qpiwsStrings.emplace_back("PV voltage high warning"); // 27
+            if ((char)commandAnswer.charAt(27) == '1') qpiwsStrings.emplace_back("MPPT overload fault"); // 28
+            if ((char)commandAnswer.charAt(28) == '1') qpiwsStrings.emplace_back("MPPT overload warning"); // 29
+            if ((char)commandAnswer.charAt(29) == '1') qpiwsStrings.emplace_back("Battery too low to charge warning"); // 30
+            if (!qpiwsStrings.empty())
+            {
+                String qpiwsStr = "";
+                for (size_t i = 0; i < qpiwsStrings.size(); i++) {
+                    qpiwsStr += qpiwsStrings[i];
+                    if (i < qpiwsStrings.size() - 1) {
+                        qpiwsStr += "; ";
+                    }
+                }
+                liveData["Fault_or_Warning"] = qpiwsStr;
+            }
+            else
+            {
+                liveData["Fault_or_Warning"] = "None";
+            }
+        }
+        return true;
+    }
+    else if (protocol == NoD)
+    {
+        return false;
+    }
+    else
+    {
+        return false;
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -578,6 +578,7 @@ bool sendtoMQTT()
     mqttclient.publish(topicBuilder(buff, "RAW/QMOD"), (mppClient.get.raw.qmod).c_str());
     mqttclient.publish(topicBuilder(buff, "RAW/QALL"), (mppClient.get.raw.qall).c_str());
     mqttclient.publish(topicBuilder(buff, "RAW/QMN"), (mppClient.get.raw.qmn).c_str());
+    mqttclient.publish(topicBuilder(buff, "RAW/QPIWS"), (mppClient.get.raw.qpiws).c_str());
   }
   else
   {


### PR DESCRIPTION
Basic support of PI30 'QPIWS' (Device Warning Status inquiry): storing RAW answer to 'Device/RAW/QPIWS' topic; 'None' or list of fault and/or warnings to 'Device/LiveData/Fault_or_Warning' topic